### PR TITLE
Allow running separate tunnels for each service

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,26 +14,13 @@
 
 ---
 
-- [Quick Start](#quick-start)
 - [One-time Setup](#one-time-setup)
     + [SSH Setup](#ssh-setup)
     + [Register new user](#register-new-user)
     + [Install the Ruby Client](#install-the-ruby-client)
+- [Run](#run)
 - [Playbook Developer Setup](#playbook-developer-setup)
 
-
-# Quick Start
-
-⚠️ **NOTE**: Make sure you've completed the **one-time setup** below before running this
-
-
-```bash
-tunnel-vision start -u $USER
-```
-
-Ensure the local application you are tunneling to is running locally. See `--help` menu for options to set local hostname and port on the tunnel connection.
-
-Then visit `"https://$USER.pipe.cr-tunnel.xyz/"` in your browser.
 
 # One-time Setup
 
@@ -60,14 +47,13 @@ Match host pipe.cr-tunnel.xyz user exec
 
 ### Register new user
 
-Submit a pull request to add your name, public key, and port to the [`tunnel_users` in the configuration file](roles/tunnel-server/vars/main.yml).
+Submit a pull request to add your name and public key to the [`tunnel_users` in the configuration file](roles/tunnel-server/vars/main.yml).
 
 Example:
 
 ```yaml
 tunnel_users:
   - name: abhishek
-    unique_port: 1738
     public_key: ssh-rsa AAAAB3NzaC1...
 ```
 
@@ -76,6 +62,27 @@ tunnel_users:
 ```bash
 curl --silent 'https://raw.githubusercontent.com/abhchand/tunnel-vision/master/lib/client/ruby/install.sh' | sh
 ```
+
+# Run
+
+You'll need to start a separate tunnel for _each target application_ you'd like to connect to.
+
+Start your application (either manually, with `docker`, etc...)
+
+```bash
+bundle exec rails server -b 0.0.0.0 -p 3000 -e development
+```
+
+Start the tunnel to your `$APPLICATION` (`callrail`, `swappy`, etc..) on the same `host` and `port`
+
+```bash
+tunnel-vision start -u $USER -a $APPLICATION -h 0.0.0.0 -p 3000
+```
+
+Visit `https://$USER-$APPLICATION.pipe.cr-tunnel.xyz/` in your browser.
+
+**NOTE**: If your application is `callrail`, you can visit `https://$USER.pipe.cr-tunnel.xyz/` as a shortcut.
+
 
 # Playbook Developer Setup
 

--- a/roles/tunnel-server/tasks/certificates.yml
+++ b/roles/tunnel-server/tasks/certificates.yml
@@ -75,6 +75,17 @@
   notify:
     - Restart Nginx
 
+- name: Re-generate users.json
+  when: app_domain_certs_exist|d(False) == True
+  template:
+    src: users.json.j2
+    dest: "{{ app_webroot }}/users.json"
+    owner: "{{ nginx_user }}"
+    group: "{{ nginx_user }}"
+    mode: 0755
+  notify:
+    - Restart Nginx
+
 
 # Certbot automatically schedules itself to check twice a day
 # for renewal (`certbot renew`). It registers itself as a system

--- a/roles/tunnel-server/templates/site-https.conf.j2
+++ b/roles/tunnel-server/templates/site-https.conf.j2
@@ -53,7 +53,7 @@ server {
 
     {% for user in tunnel_users %}
     if ($user ~* "{{ user.name }}") {
-      set  $tunnel_port  {{ user.unique_port }};
+      set  $tunnel_port  {{ services[0].base_port + loop.index }};
     }
     {% endfor -%}
 
@@ -63,23 +63,26 @@ server {
     proxy_set_header  X-Real-IP  $remote_addr;
     proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header  X-Original-Host $http_host;
-    proxy_set_header  Host {{ localhost_target_default }};
-    proxy_redirect    http://{{ localhost_target_default }}/ http://$http_host/;
+    proxy_set_header  Host {{ services[0].name }}.test;
+    proxy_redirect    http://{{ services[0].name }}.test/ http://$http_host/;
     proxy_pass        http://127.0.0.1:$tunnel_port;
 
     access_log /var/log/nginx/tunnel.log;
   }
 }
 
+{% for service in services %}
+
 #
-# Forward any requests to <user>-<application>.{{ app_domain }} to the appropriate
+# {{ service.name }}
+# Forward any requests to <user>-{{ service.name }}.{{ app_domain }} to the appropriate
 # local tunnel
 #
 
 server {
   listen 443 ssl;
 
-  server_name  ~^(?<user>([^.-]+))\-(?<application>([^.]+))\.{{ app_domain | replace(".", "\\.") }};
+  server_name  ~^(?<user>([^.-]+))\-{{ service.name }}\.{{ app_domain | replace(".", "\\.") }};
 
   client_max_body_size 100M;
 
@@ -90,7 +93,7 @@ server {
 
     {% for user in tunnel_users %}
     if ($user ~* "{{ user.name }}") {
-      set  $tunnel_port  {{ user.unique_port }};
+      set  $tunnel_port  {{ service.base_port + loop.index }};
     }
     {% endfor -%}
 
@@ -100,10 +103,12 @@ server {
     proxy_set_header  X-Real-IP  $remote_addr;
     proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header  X-Original-Host $http_host;
-    proxy_set_header  Host {{ localhost_target_application }};
-    proxy_redirect    http://{{ localhost_target_application }}/ http://$http_host/;
+    proxy_set_header  Host {{ service.name }}.test;
+    proxy_redirect    http://{{ service.name }}.test/ http://$http_host/;
     proxy_pass        http://127.0.0.1:$tunnel_port;
 
     access_log /var/log/nginx/tunnel.log;
   }
 }
+
+{% endfor -%}

--- a/roles/tunnel-server/templates/users.json.j2
+++ b/roles/tunnel-server/templates/users.json.j2
@@ -1,0 +1,10 @@
+{
+  {% for u in tunnel_users %}
+  {% set offset = loop.index %}
+  "{{ u.name }}": {
+    {% for s in services %}
+    "{{ s.name }}": {{ s.base_port + offset }}{{ '' if loop.last else ',' }}
+    {% endfor -%}
+  }{{ '' if loop.last else ',' }}
+  {% endfor %}
+}

--- a/roles/tunnel-server/vars/main.yml
+++ b/roles/tunnel-server/vars/main.yml
@@ -9,9 +9,6 @@ app_webroot: /var/www/data/pipe.cr-tunnel.xyz
 exec_user: exec
 nginx_user: www-data
 
-localhost_target_default: callrail.test
-localhost_target_application: $application.test
-
 ssl_management_user: root
 certbot_scripts_dir: /usr/local/bin
 letsencrypt_dir: /etc/letsencrypt
@@ -35,10 +32,16 @@ digitalocean_api_key: !vault |
   63373436396232383264366231636562663434383831623161333732663564313935326138313164
   37643564653633333663
 
+# Note: The first service in the list will be the default
+# target for the "$user.$app_domain" subdomain.
+services:
+  - name: callrail
+    base_port: 4000
+  - name: swappy
+    base_port: 5000
+
 tunnel_users:
   - name: abhishek
-    unique_port: 6000
     public_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDc39+FW+8MNBVvebukjXT3NMmbe7Y1np6AZED1hNOJ7yN5KLtMTQR+VQoRPdeQmjcUmuieW3+Oroa6l2+WxaqJNMYrdplVdXbFLXEIw2D4/2c2z5U+I4Cg4x1hBCLKoNk9fYzJunhT0jusMU4x7HeQUtpPENOeuBR4jpr4xr3pTi05z5yxJLCSiEXQC+oULLO5MvVwbSC2C/vXNqTHuM4yMFM2T1O0oWfEiLJzhKhGmrMkwyqEtQ8ghZ3DmIaDkb2p9nMpBdrkdivZsu0PwEmNs+zMXWqMsm2gDbMqYGKuIUh7a1wkn51KwlQVtFWRddQgWQrewF3c2lHObqjt2HJnR9zT8K1aSKfs3d8AuBMg97xdVsB1nKBIwooUZAiqYTM+O4Jw/IKEoCtWKPyUzYAW0Fyvy9Na68d+dO+OR6LznXeoH/xoc5bCEbJQVWe3jFcf5Jc93lk6zPYtOK2x4QkRcWI5/9LvYw6nP/Jnr7jANSzQCIwZG22zmGZcBUNbzOs= abhishek@abhishekchandrasekhar.local
   - name: leo
-    unique_port: 6001
     public_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC/3XpiP/4MdEBBp1x5WCECMxcaQTOEuNay69j/KC9xv4CNlF4fn2FeALopeiA7furlHjiwmc508pZ2afYi5TLbCiCjSdX5wvCALVV7/ZEOJxldcfhPaC6MdMnF48GOoV526oOsOPh2CYKmpkio6SpMHn7kyujsnr/yKtKrgQf9mDErVdzFIHINXuHjEOJnLVlOFLUH7ufFas0emMYeENsRj00ekgF3TGUAj7adSwzmBC6V7WrPp9kYKd6KymH+Whf1V1csUPuJFEZItMovUMIPDaufc/WTMllYEGajR3U8L/fIT5iMUs93hGdkmmMJ/5lhQuZmU0M7PYjetmL3Pifw67XVp7F1x3843EKEyyQxU7WKVFEfQH7t+QFmwZdqYsKLk2+42FWj2Nv0+rRnd8poh4L5anfU4QpcDKPk6jm8JUPcTT6zqYm9mDMBCMkt50qJ6HIHFE13sYS9UtRwH0RMPB/bSmZuKgAKGNGt3mZxn84x//VWa1yRc3iSXLCJvu0= abc@pipe.com


### PR DESCRIPTION
We need to allow a single user running multiple tunnels - one for each service.

- [x] Update `nginx` configuration to support multiple applications with different base host port numbers
- [x] Generate a `/users.json` static file the client can use to retrieve the mapping

# Screenshots

<img width="1665" alt="Screen Shot 2021-05-25 at 4 44 17 PM" src="https://user-images.githubusercontent.com/13787645/119566111-c5f7ab00-bd78-11eb-85ea-8b823cbcb125.png">
